### PR TITLE
Stop the vehicle as a failsafe on client side disconnection

### DIFF
--- a/api/v1/views/events.py
+++ b/api/v1/views/events.py
@@ -1,5 +1,5 @@
 from flask import session, Flask, jsonify, json, render_template, request
-from flask_socketio import emit, join_room, leave_room
+from flask_socketio import emit, join_room, leave_room, disconnect
 import os
 import sys
 import time
@@ -21,8 +21,12 @@ def acknowledge(json, methods=['GET', 'POST']):
     # print('received eggplant: ' + str(json))    
     print(str(json))
     json['response'] = 'Socket + server connection established.'
+
     emit('my response', json, callback=socketCallback)
 
+@socketio.on('disconnect')
+def acknowledgeDisconnect():
+    print('Client disconnected', request.sid)
 
 @socketio.on('retrieve session info')
 def sessionInfo(json, methods=['GET']):

--- a/api/v1/views/events.py
+++ b/api/v1/views/events.py
@@ -24,10 +24,6 @@ def acknowledge(json, methods=['GET', 'POST']):
 
     emit('my response', json, callback=socketCallback)
 
-@socketio.on('disconnect')
-def acknowledgeDisconnect():
-    print('Client disconnected', request.sid)
-
 @socketio.on('retrieve session info')
 def sessionInfo(json, methods=['GET']):
     print('connected!')

--- a/api/v1/views/motor.py
+++ b/api/v1/views/motor.py
@@ -1,6 +1,6 @@
 from . import app_views
 from flask import session, Flask, jsonify, json, render_template, request
-from flask_socketio import emit, join_room, leave_room
+from flask_socketio import emit, join_room, leave_room, disconnect
 from flask_cors import CORS, cross_origin
 from ..models import Motor, easeFunctions
 import os
@@ -133,6 +133,13 @@ def goToWaypoint(id):
         return jsonify(500)
 
 
+###################### MISC SOCKET EVENTS / FAIL SAFE  #########################
+@socketio.on('disconnect')
+def acknowledgeDisconnect():
+    print('Client disconnected. Fail safe activated', request.sid)
+    if (motor.shouldMove):
+        motor.shouldMove = False
+        print("Stopping motor. Steps Taken = {}".format(motor.stepsTaken))
 
 '''
      

--- a/client/src/contexts/AppSettingsContext.js
+++ b/client/src/contexts/AppSettingsContext.js
@@ -127,6 +127,9 @@ const AppSettingsContextProvider = ({ children }) => {
     socket.on('disconnect', function(){
         // console.log("socket server has been disconnected");
         setHasSocketConnection(false);
+
+        // Killswitch on the vehicle on disconnect
+        emit('control vehicle', {dir: 0, shouldMove: false});
     });
 
     const testSocketConnection = () => {        


### PR DESCRIPTION
This will help make sure that the vehicle does not erroneously continue to move if the following are true:
1. The client has disconnected from the server (e.g. being too far away from the vehicle)
2. A move command has been issued but a stop command has not

Note: this only applies to manual movement of the vehicle, movements based on routes are not affected.